### PR TITLE
Update unit_transport_preserve_queue.lua

### DIFF
--- a/unit_transport_preserve_queue.lua
+++ b/unit_transport_preserve_queue.lua
@@ -13,6 +13,8 @@ end
 
 local CMD_MOVE = CMD.MOVE
 local CMD_GUARD = CMD.GUARD
+local CMD_LOAD_UNITS = CMD.LOAD_UNITS
+local CMD_LOAD_ONTO = CMD.LOAD_ONTO
 local CMD_WAIT = CMD.WAIT
 local CMD_INSERT = CMD.INSERT
 local CMD_OPT_SHIFT = CMD.OPT_SHIFT
@@ -51,7 +53,7 @@ function widget:Update()
 			local hasSeenValidCommandToPreserve = false
 			for i = 1, #oldBuildQueue do
 				local cmd = oldBuildQueue[i]
-				if cmd['id'] ~= CMD_MOVE and cmd['id'] ~= CMD_GUARD then
+				if cmd['id'] ~= CMD_MOVE and cmd['id'] ~= CMD_GUARD and cmd['id'] ~= CMD_LOAD_UNITS and cmd['id'] ~= CMD_LOAD_ONTO then
 					hasSeenValidCommandToPreserve = true
 				end
 				if hasSeenValidCommandToPreserve then	

--- a/unit_transport_preserve_queue.lua
+++ b/unit_transport_preserve_queue.lua
@@ -15,6 +15,9 @@ local CMD_MOVE = CMD.MOVE
 local CMD_GUARD = CMD.GUARD
 local CMD_LOAD_UNITS = CMD.LOAD_UNITS
 local CMD_LOAD_ONTO = CMD.LOAD_ONTO
+local CMD_FIGHT = CMD.FIGHT
+local CMD_RECLAIM = CMD.RECLAIM
+local CMD_REPAIR = CMD.REPAIR
 local CMD_WAIT = CMD.WAIT
 local CMD_INSERT = CMD.INSERT
 local CMD_OPT_SHIFT = CMD.OPT_SHIFT
@@ -53,7 +56,7 @@ function widget:Update()
 			local hasSeenValidCommandToPreserve = false
 			for i = 1, #oldBuildQueue do
 				local cmd = oldBuildQueue[i]
-				if cmd['id'] ~= CMD_MOVE and cmd['id'] ~= CMD_GUARD and cmd['id'] ~= CMD_LOAD_UNITS and cmd['id'] ~= CMD_LOAD_ONTO then
+				if cmd['id'] ~= CMD_MOVE and cmd['id'] ~= CMD_GUARD and cmd['id'] ~= CMD_LOAD_UNITS and cmd['id'] ~= CMD_LOAD_ONTO and cmd['id'] ~= CMD_FIGHT and cmd['id'] ~= CMD_RECLAIM and cmd['id'] ~= CMD_REPAIR then
 					hasSeenValidCommandToPreserve = true
 				end
 				if hasSeenValidCommandToPreserve then	


### PR DESCRIPTION
If you have regular unit selected and target the transport (instead of other way around), the last command (in this case order to load the unit) persists and the first thing the unit does after being unloaded is to ask to be immediately loaded again, resulting in endless cycle.

You were talking about automatically removing all move commands at the front of the command que. Looks like having the script remove the load command solves this.