### PR TITLE
Fixed capitalization issue of RemoveWidget

### DIFF
--- a/unit_transport_preserve_queue.lua
+++ b/unit_transport_preserve_queue.lua
@@ -29,7 +29,7 @@ local recentlyUnloaded = {}
 
 function widget:Initialize()
 	if Spring.GetSpectatingState() then
-		widgetHandler:removeWidget()
+		widgetHandler:RemoveWidget()
 	end
 end
 


### PR DESCRIPTION
RemoveWidget was miscapitalized as removeWidget, resulting in a LuaUI error every time this widget was loaded in a spectator game.